### PR TITLE
Issue 13 save and recall last preset used

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1742,7 +1742,7 @@ module.exports = {
 						type: 'dropdown',
 						label: 'Preset Number',
 						id: 'val',
-						default: c.CHOICES_PRESETS()[0].id,
+						default: c.CHOICES_PRESETS()[1].id,
 						choices: c.CHOICES_PRESETS(),
 					},
 					{
@@ -1790,7 +1790,13 @@ module.exports = {
 					}
 				],
 				callback: function (action, bank) {
-					cmd = 'p=' + action.options.val + '&name=' + action.options.name;
+					if (action.options.val === 0) {
+						cmd = 'p=' + self.data.presetLastUsed;
+					}
+					else {
+						cmd = 'p=' + action.options.val;
+					}
+					cmd += '&name=' + action.options.name;
 					if ((action.options.save_ptz) && (action.options.save_focus) && (action.options.save_exposure) && (action.options.save_whitebalance) && (action.options.save_is) && (action.options.save_cp)) {
 						cmd += '&all=enabled';
 					}
@@ -1843,7 +1849,7 @@ module.exports = {
 						type: 'dropdown',
 						label: 'Preset Number',
 						id: 'val',
-						default: c.CHOICES_PRESETS()[0].id,
+						default: c.CHOICES_PRESETS()[1].id,
 						choices: c.CHOICES_PRESETS(),
 					},
 				],
@@ -1854,7 +1860,13 @@ module.exports = {
 						self.data.presetRecallMode = 'normal';
 					}
 
-					cmd = 'p=' + action.options.val;
+					if (action.options.val === 0) {
+						cmd = 'p=' + self.data.presetLastUsed;
+					}
+					else {
+						cmd = 'p=' + action.options.val;
+						self.data.presetLastUsed = action.options.val;
+					}
 
 					switch(self.presetRecallMode) {
 						case 'time':
@@ -1864,8 +1876,6 @@ module.exports = {
 							cmd += '&p.ptzspeed=' + self.data.presetSpeedValue;
 							break;
 					}
-
-					self.data.presetLastUsed = action.options.val;
 
 					self.sendPTZ(cmd);
 				}

--- a/src/choices.js
+++ b/src/choices.js
@@ -560,6 +560,7 @@ module.exports = {
 
 	CHOICES_PRESETS: function () {
 		var p = [];
+		p.push({ id: 0, label: 'Last Preset Used'})
 		for (let i = 1; i <= 100; i++) {
 			p.push({ id: i, label: 'Preset ' + i})
 		}

--- a/src/presets.js
+++ b/src/presets.js
@@ -2153,6 +2153,33 @@ module.exports = {
 				})
 			}
 
+			presets.push({
+				category: 'Save Preset',
+				label: 'Save Last Preset',
+				bank: {
+					style: 'text',
+					text: 'Save\\nLast PSET\\n$(canon-ptz:presetLastUsed)',
+					size: '14',
+					color: '16777215',
+					bgcolor: self.rgb(0, 0, 0)
+				},
+				actions: [
+					{
+						action: 'savePset',
+						options: {
+							val: 0,
+							name: 'Last Preset Used',
+							save_ptz: true,
+							save_focus: true,
+							save_exposure: true,
+							save_whitebalance: true,
+							save_is: true,
+							save_cp: true
+						}
+					}
+				]
+			})
+
 			for (var recall = 1; recall <= 100; recall++) {
 				presets.push({
 					category: 'Recall Preset',
@@ -2192,11 +2219,19 @@ module.exports = {
 				label: 'Preset Last Used',
 				bank: {
 					style: 'text',
-					text: '$(canon-ptz:presetLastUsed)',
+					text: 'Recall\\nLast PSET\\n$(canon-ptz:presetLastUsed)',
 					size: '14',
 					color: '16777215',
 					bgcolor: self.rgb(0, 0, 0)
-				}
+				},
+				actions: [
+					{
+						action: 'recallPset',
+						options: {
+							val: 0
+						}
+					}
+				]
 			})
 		}		
 


### PR DESCRIPTION
These changes provide the ability to save PTZ camera setting to the last preset used.  It also enables a user to recall the last preset used to recall settings after any manual adjustments to the camera.  Two new companion presets where also added to provide examples on how to use this functionality.