### PR TITLE
Preset save options: module-owned toggles, action, feedback and presets

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -113,6 +113,7 @@ The actions are separated into the following categories:
   - **Module toggles** — the module's own switches, shared by every Save button pointed at them. Flip them with the **Preset - Set Save Option** action (each option, or All, set On/Off/Toggle). Nothing has to be created first: the toggles ship with the module, default to all on, read back as the `savePresetOption_*` variables, and are remembered across a restart.
   - **Variables** — point each option at any variable holding true/false, 1/0, yes/no or on/off.
 - The **Preset Save Options** preset category has a ready-made switch per option (green when that option is being saved, dark when it is not), an All button, and a summary button. Drop them on a page next to any Save Preset button set to "Module toggles" to pick what a save writes without editing that button again.
+- (Module toggles for the save options were written with @claude.)
 
 **Recall Presets**
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -108,7 +108,11 @@ The actions are separated into the following categories:
 **Save presets**
 
 - Save Preset 1-100, with options to set name and settings to save (ptz, focus, exposure, etc.)
-- The save options can be driven by variables instead of checkboxes — tick "Use variables for the save options below" and point each one at a variable holding true/false. One set of custom variables can then change what every camera saves, without editing each button.
+- "Where the save options come from" chooses how a Save Preset button decides what to write:
+  - **This button** — the checkboxes on the button itself. This is the default and how Save Preset has always worked.
+  - **Module toggles** — the module's own switches, shared by every Save button pointed at them. Flip them with the **Preset - Set Save Option** action (each option, or All, set On/Off/Toggle). Nothing has to be created first: the toggles ship with the module, default to all on, read back as the `savePresetOption_*` variables, and are remembered across a restart.
+  - **Variables** — point each option at any variable holding true/false, 1/0, yes/no or on/off.
+- The **Preset Save Options** preset category has a ready-made switch per option (green when that option is being saved, dark when it is not), an All button, and a summary button. Drop them on a page next to the **Save Preset (Module Toggles)** buttons to pick what a save writes without editing any button.
 
 **Recall Presets**
 
@@ -179,6 +183,8 @@ A list of all the available Variables in this module sorted into the following c
 - Preset Recall Mode
 - Preset Time Value
 - Preset Speed Value
+- Save Preset Option ON/OFF, one per option (`savePresetOption_ptz`, `_focus`, `_exposure`, `_whitebalance`, `_is`, `_cp`)
+- Save Preset Options summary, e.g. `PTZ, Exp, WB` (`savePresetOptions`)
 
 ## Feedbacks
 
@@ -206,6 +212,7 @@ A list of all the available Feedbacks in this module sorted into the following c
 
 - Preset Last Used
 - Preset Recall Mode
+- Preset Save Option State — whether one option (or All) is currently set to be saved
 
 **Custom**
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -112,7 +112,7 @@ The actions are separated into the following categories:
   - **This button** — the checkboxes on the button itself. This is the default and how Save Preset has always worked.
   - **Module toggles** — the module's own switches, shared by every Save button pointed at them. Flip them with the **Preset - Set Save Option** action (each option, or All, set On/Off/Toggle). Nothing has to be created first: the toggles ship with the module, default to all on, read back as the `savePresetOption_*` variables, and are remembered across a restart.
   - **Variables** — point each option at any variable holding true/false, 1/0, yes/no or on/off.
-- The **Preset Save Options** preset category has a ready-made switch per option (green when that option is being saved, dark when it is not), an All button, and a summary button. Drop them on a page next to the **Save Preset (Module Toggles)** buttons to pick what a save writes without editing any button.
+- The **Preset Save Options** preset category has a ready-made switch per option (green when that option is being saved, dark when it is not), an All button, and a summary button. Drop them on a page next to any Save Preset button set to "Module toggles" to pick what a save writes without editing that button again.
 
 **Recall Presets**
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -2202,108 +2202,44 @@ module.exports = {
 						useVariables: true
 					},
 					{
-						type: 'checkbox',
-						label: 'Use variables for the save options below',
-						id: 'use_variables_save',
-						default: false,
-						tooltip: 'Drive each option from a variable so one set of switches can change what every camera saves.'
+						type: 'dropdown',
+						label: 'Where the save options come from',
+						id: 'save_source',
+						default: 'button',
+						choices: [
+							{ id: 'button', label: 'This button (checkboxes below)' },
+							{ id: 'module', label: 'Module toggles (shared by every Save button)' },
+							{ id: 'variables', label: 'Variables' },
+						],
+						tooltip: 'Module toggles are flipped by the "Preset - Set Save Option" action, so one set of switches changes what every Save button writes.'
 					},
 					{
-						type: 'checkbox',
-						label: 'Save Position (PTZ)',
-						id: 'save_ptz',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
+						type: 'static-text',
+						id: 'save_module_info',
+						label: 'Module Toggles',
+						value: 'This button follows the module toggles. Flip them with the "Preset - Set Save Option" action, or with the buttons in the "Preset Save Options" preset category. Current state: $(canon-ptz:savePresetOptions)',
+						isVisible: (options) => options['save_source'] === 'module',
 					},
-					{
-						type: 'textinput',
-						label: 'Save Position (PTZ)',
-						id: 'save_ptz_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
-					{
-						type: 'checkbox',
-						label: 'Save Focus',
-						id: 'save_focus',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
-					},
-					{
-						type: 'textinput',
-						label: 'Save Focus',
-						id: 'save_focus_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
-					{
-						type: 'checkbox',
-						label: 'Save Exposure',
-						id: 'save_exposure',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
-					},
-					{
-						type: 'textinput',
-						label: 'Save Exposure',
-						id: 'save_exposure_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
-					{
-						type: 'checkbox',
-						label: 'Save White Balance',
-						id: 'save_whitebalance',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
-					},
-					{
-						type: 'textinput',
-						label: 'Save White Balance',
-						id: 'save_whitebalance_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
-					{
-						type: 'checkbox',
-						label: 'Save Image Stabilization (IS)',
-						id: 'save_is',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
-					},
-					{
-						type: 'textinput',
-						label: 'Save Image Stabilization (IS)',
-						id: 'save_is_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
-					{
-						type: 'checkbox',
-						label: 'Save CP',
-						id: 'save_cp',
-						default: true,
-						isVisible: (options) => !options['use_variables_save'],
-					},
-					{
-						type: 'textinput',
-						label: 'Save CP',
-						id: 'save_cp_v',
-						default: 'true',
-						tooltip: 'true/false, 1/0, yes/no, on/off.',
-						useVariables: true,
-						isVisible: (options) => !!options['use_variables_save'],
-					},
+					//The checkbox and the variable input for each option are built from
+					//the same list, so the six stay in step with the command builder below
+					...c.SAVE_PRESET_OPTIONS.flatMap((option) => ([
+						{
+							type: 'checkbox',
+							label: 'Save ' + option.label,
+							id: option.id,
+							default: true,
+							isVisible: (options) => (options['save_source'] ?? 'button') === 'button',
+						},
+						{
+							type: 'textinput',
+							label: 'Save ' + option.label,
+							id: option.id + '_v',
+							default: 'true',
+							tooltip: 'true/false, 1/0, yes/no, on/off.',
+							useVariables: true,
+							isVisible: (options) => options['save_source'] === 'variables',
+						},
+					])),
 				],
 				callback: async (action) => {
 					let presetName = await self.parseVariablesInString(action.options.name);
@@ -2318,57 +2254,32 @@ module.exports = {
 						return;
 					}
 
-					//each option is either its checkbox or a variable that resolves to one
+					//each option comes from this button, from the module toggles, or from
+					//a variable that resolves to one. Buttons saved before save_source
+					//existed only carry the old use_variables_save checkbox.
+					let source = action.options.save_source ?? (action.options.use_variables_save ? 'variables' : 'button');
+
 					let saveOptions = {};
-					for (const key of ['save_ptz', 'save_focus', 'save_exposure', 'save_whitebalance', 'save_is', 'save_cp']) {
-						if (action.options.use_variables_save) {
-							saveOptions[key] = self.parseBoolean(await self.parseVariablesInString(action.options[key + '_v']));
+					for (const option of c.SAVE_PRESET_OPTIONS) {
+						if (source === 'variables') {
+							saveOptions[option.key] = self.parseBoolean(await self.parseVariablesInString(action.options[option.id + '_v']));
+						}
+						else if (source === 'module') {
+							saveOptions[option.key] = self.data.savePresetOptions[option.key] == true;
 						}
 						else {
-							saveOptions[key] = !!action.options[key];
+							saveOptions[option.key] = !!action.options[option.id];
 						}
 					}
 
 					cmd = 'p=' + presetNumber + '&name=' + presetName;
-					if ((saveOptions.save_ptz) && (saveOptions.save_focus) && (saveOptions.save_exposure) && (saveOptions.save_whitebalance) && (saveOptions.save_is) && (saveOptions.save_cp)) {
+
+					if (c.SAVE_PRESET_OPTIONS.every((option) => saveOptions[option.key])) {
 						cmd += '&all=enabled';
 					}
 					else {
-						if (saveOptions.save_ptz) {
-							cmd += '&ptz=enabled';
-						}
-						else {
-							cmd += '&ptz=disabled';
-						}
-						if (saveOptions.save_focus) {
-							cmd += '&focus=enabled';
-						}
-						else {
-							cmd += '&focus=disabled';
-						}
-						if (saveOptions.save_exposure) {
-							cmd += '&exp=enabled';
-						}
-						else {
-							cmd += '&exp=disabled';
-						}
-						if (saveOptions.save_whitebalance) {
-							cmd += '&wb=enabled';
-						}
-						else {
-							cmd += '&wb=disabled';
-						}
-						if (saveOptions.save_is) {
-							cmd += '&is=enabled';
-						}
-						else {
-							cmd += '&is=disabled';
-						}
-						if (saveOptions.save_cp) {
-							cmd += '&cp=enabled';
-						}
-						else {
-							cmd += '&cp=disabled';
+						for (const option of c.SAVE_PRESET_OPTIONS) {
+							cmd += '&' + option.cmd + '=' + (saveOptions[option.key] ? 'enabled' : 'disabled');
 						}
 					}
 
@@ -2378,6 +2289,37 @@ module.exports = {
 					self.checkFeedbacks();
 
 					self.sendPTZ(self.savePresetCommand, cmd);
+				}
+			}
+
+			actions.savePresetOption = {
+				name: 'Preset - Set Save Option',
+				options: [
+					{
+						type: 'dropdown',
+						label: 'Option',
+						id: 'option',
+						default: 'ptz',
+						choices: [
+							...c.CHOICES_SAVE_PRESET_OPTIONS(),
+							{ id: 'all', label: 'All Options' },
+						],
+					},
+					{
+						type: 'dropdown',
+						label: 'State',
+						id: 'state',
+						default: 'toggle',
+						choices: [
+							{ id: 'toggle', label: 'Toggle' },
+							{ id: 'true', label: 'On (save it)' },
+							{ id: 'false', label: 'Off (leave it alone)' },
+						],
+						tooltip: 'Toggle All flips each option on its own rather than forcing them all one way.'
+					},
+				],
+				callback: async (action) => {
+					self.setSavePresetOption(action.options.option, action.options.state);
 				}
 			}
 

--- a/src/choices.js
+++ b/src/choices.js
@@ -742,6 +742,29 @@ module.exports = {
 		return p
 	},
 
+	// #####################################
+	// #### Preset Save Option Look Ups ####
+	// #####################################
+
+	//The six things a Save Preset can write. One list feeds the action options,
+	//the module toggles, the variables, the feedback and the presets, so a
+	//seventh option only has to be added here.
+	//  key   - suffix for the module state, variable and feedback
+	//  id    - the existing savePset option id, kept for backwards compatibility
+	//  cmd   - the parameter name the camera expects
+	SAVE_PRESET_OPTIONS: [
+		{ key: 'ptz',          id: 'save_ptz',          cmd: 'ptz',   label: 'Position (PTZ)',          short: 'PTZ' },
+		{ key: 'focus',        id: 'save_focus',        cmd: 'focus', label: 'Focus',                   short: 'Focus' },
+		{ key: 'exposure',     id: 'save_exposure',     cmd: 'exp',   label: 'Exposure',                short: 'Exp' },
+		{ key: 'whitebalance', id: 'save_whitebalance', cmd: 'wb',    label: 'White Balance',           short: 'WB' },
+		{ key: 'is',           id: 'save_is',           cmd: 'is',    label: 'Image Stabilization (IS)', short: 'IS' },
+		{ key: 'cp',           id: 'save_cp',           cmd: 'cp',    label: 'CP',                      short: 'CP' },
+	],
+
+	CHOICES_SAVE_PRESET_OPTIONS: function () {
+		return this.SAVE_PRESET_OPTIONS.map((option) => ({ id: option.key, label: option.label }))
+	},
+
 	// ###############################
 	// #### Preset Speed Look Ups ####
 	// ###############################

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -703,6 +703,50 @@ module.exports = {
 			}
 		}
 
+		if (SERIES.actions.presets == true) {
+			feedbacks.savePresetOption = {
+				type: 'boolean',
+				name: 'Preset - Save Option State',
+				description: 'Indicate whether a Save Preset option is currently ON or OFF',
+				defaultStyle: {
+					color: foregroundColor,
+					bgcolor: backgroundColorGreen,
+				},
+				options: [
+					{
+						type: 'dropdown',
+						label: 'Option',
+						id: 'option',
+						default: 'ptz',
+						choices: [
+							...c.CHOICES_SAVE_PRESET_OPTIONS(),
+							{ id: 'all', label: 'All Options' },
+						],
+					},
+					{
+						type: 'dropdown',
+						label: 'Indicate in X State',
+						id: 'state',
+						default: '1',
+						choices: [
+							{ id: '0', label: 'OFF' },
+							{ id: '1', label: 'ON' },
+						],
+					},
+				],
+				callback: function (feedback, bank) {
+					let opt = feedback.options
+
+					//"All Options" is only ON when every one of them is
+					let on = (opt.option === 'all')
+						? c.SAVE_PRESET_OPTIONS.every((option) => self.data.savePresetOptions[option.key] == true)
+						: self.data.savePresetOptions[opt.option] == true;
+
+					return (opt.state === '1') ? on : !on;
+				}
+			}
+		}
+
 		feedbacks.customTraceLoop = {
 			type: 'boolean',
 			name: 'Custom Trace is Running',

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,9 @@ class canonptzInstance extends InstanceBase {
 
 		Object.assign(this, state.defaultIndexes())
 
+		//data was just rebuilt from defaults, so put the saved toggles back
+		this.loadSavePresetOptions()
+
 		this.config.host = this.config.host || ''
 		this.config.httpPort = this.config.httpPort || 80
 		this.config.model = this.config.model || 'Auto'

--- a/src/presets.js
+++ b/src/presets.js
@@ -2784,6 +2784,141 @@ module.exports = {
 			}
 		}
 
+		// #################################
+		// #### Preset Save Option Toggles ####
+		// #################################
+
+		if (s.presets == true) {
+			//One switch per thing a Save Preset can write. Green is "this gets
+			//saved", dark is "leave whatever the preset already had". Point a
+			//Save button at the module toggles and these drive it.
+			for (const option of c.SAVE_PRESET_OPTIONS) {
+				presets['savePresetOption_' + option.key] = {
+					category: 'Preset Save Options',
+					type: 'button',
+					name: 'Save Option - ' + option.label + ' On/Off',
+					style: {
+						text: option.short + '\\n$(canon-ptz:savePresetOption_' + option.key + ')',
+						size: '18',
+						color: foregroundColor,
+						bgcolor: combineRgb(40, 40, 40),
+					},
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'savePresetOption',
+									options: {
+										option: option.key,
+										state: 'toggle',
+									}
+								}
+							],
+							up: [],
+						},
+					],
+					feedbacks: [
+						{
+							feedbackId: 'savePresetOption',
+							options: {
+								option: option.key,
+								state: '1',
+							},
+							style: {
+								color: combineRgb(0, 0, 0),
+								bgcolor: backgroundColorGreen,
+							}
+						}
+					]
+				}
+			}
+
+			presets.savePresetOption_all = {
+				category: 'Preset Save Options',
+				type: 'button',
+				name: 'Save Option - All On/Off',
+				style: {
+					text: 'SAVE\\nALL',
+					size: '18',
+					color: foregroundColor,
+					bgcolor: combineRgb(40, 40, 40),
+				},
+				steps: [
+					{
+						down: [
+							{
+								actionId: 'savePresetOption',
+								options: {
+									option: 'all',
+									state: 'true',
+								}
+							}
+						],
+						up: [],
+					},
+				],
+				feedbacks: [
+					{
+						feedbackId: 'savePresetOption',
+						options: {
+							option: 'all',
+							state: '1',
+						},
+						style: {
+							color: combineRgb(0, 0, 0),
+							bgcolor: backgroundColorGreen,
+						}
+					}
+				]
+			}
+
+			presets.savePresetOption_summary = {
+				category: 'Preset Save Options',
+				type: 'button',
+				name: 'Save Options - Summary',
+				style: {
+					text: 'SAVING\\n$(canon-ptz:savePresetOptions)',
+					size: '14',
+					color: foregroundColor,
+					bgcolor: combineRgb(0, 0, 0),
+				},
+				steps: [],
+				feedbacks: []
+			}
+		}
+
+		if (s.presets == true) {
+			for (let save = 1; save <= 100; save++) {
+				presets['presetSaveToggles' + save] = {
+					category: 'Save Preset (Module Toggles)',
+					type: 'button',
+					name: 'Save Preset ' + save + ' (Module Toggles)',
+					style: {
+						text: 'SAVE\\nPSET\\n' + save + '\\n$(canon-ptz:savePresetOptions)',
+						size: '14',
+						color: foregroundColor,
+						bgcolor: combineRgb(0, 0, 0)
+					},
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'savePset',
+									options: {
+										val: save,
+										name: 'preset' + save,
+										save_source: 'module',
+									}
+								}
+							],
+							up: []
+						},
+					],
+					feedbacks: []
+				}
+			}
+		}
+
 		if (s.presets == true) {
 			for (let save = 1; save <= 100; save++) {
 				presets['presetSave' + save] = {
@@ -2804,6 +2939,7 @@ module.exports = {
 									options: {
 										val: save,
 										name: 'preset' + save,
+										save_source: 'button',
 										save_ptz: true,
 										save_focus: true,
 										save_exposure: true,

--- a/src/presets.js
+++ b/src/presets.js
@@ -2889,38 +2889,6 @@ module.exports = {
 
 		if (s.presets == true) {
 			for (let save = 1; save <= 100; save++) {
-				presets['presetSaveToggles' + save] = {
-					category: 'Save Preset (Module Toggles)',
-					type: 'button',
-					name: 'Save Preset ' + save + ' (Module Toggles)',
-					style: {
-						text: 'SAVE\\nPSET\\n' + save + '\\n$(canon-ptz:savePresetOptions)',
-						size: '14',
-						color: foregroundColor,
-						bgcolor: combineRgb(0, 0, 0)
-					},
-					steps: [
-						{
-							down: [
-								{
-									actionId: 'savePset',
-									options: {
-										val: save,
-										name: 'preset' + save,
-										save_source: 'module',
-									}
-								}
-							],
-							up: []
-						},
-					],
-					feedbacks: []
-				}
-			}
-		}
-
-		if (s.presets == true) {
-			for (let save = 1; save <= 100; save++) {
 				presets['presetSave' + save] = {
 					category: 'Save Preset',
 					type: 'button',

--- a/src/state.js
+++ b/src/state.js
@@ -92,6 +92,20 @@ module.exports = {
 			presetRecallMode: 'normal',
 			presetTimeValue: 2000,
 			presetSpeedValue: 1,
+
+			//Save Preset options. Module-owned toggles, so a Save Preset button can
+			//follow a set of switches without the user building custom variables
+			//first. Restored from config in loadSavePresetOptions() -- defaultData()
+			//runs again on every configUpdated(), which would otherwise reset these
+			//every time somebody opened the config page.
+			savePresetOptions: {
+				ptz: true,
+				focus: true,
+				exposure: true,
+				whitebalance: true,
+				is: true,
+				cp: true,
+			},
 	
 			trackingConfig: {},
 			trackingInformation: {},

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -6,4 +6,32 @@ module.exports = [
 			updatedFeedbacks: [],
 		}
 	},
+
+	//"Use variables for the save options" was a checkbox before the save options
+	//could also come from the module toggles. Fold the old checkbox into the
+	//save_source dropdown so existing Save Preset buttons keep their behaviour.
+	function (context, props) {
+		const updatedActions = []
+
+		for (const action of props.actions) {
+			if (action.actionId !== 'savePset') {
+				continue
+			}
+
+			if (action.options.save_source !== undefined) {
+				continue
+			}
+
+			action.options.save_source = action.options.use_variables_save ? 'variables' : 'button'
+			delete action.options.use_variables_save
+
+			updatedActions.push(action)
+		}
+
+		return {
+			updatedConfig: null,
+			updatedActions: updatedActions,
+			updatedFeedbacks: [],
+		}
+	},
 ]

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const { MODELS, SERIES_SPECS } = require('./models.js')
+const c = require('./choices.js')
 
 module.exports = {
 	//Resolve the configured or camera-reported model name to its SERIES_SPECS
@@ -233,6 +234,50 @@ module.exports = {
 		const text = String(value).trim().toLowerCase();
 
 		return text === 'true' || text === '1' || text === 'yes' || text === 'on' || text === 'enabled';
+	},
+
+	//Bring the save option toggles back from config. They live in config rather
+	//than in data alone so a toggle set before doors survives a Companion
+	//restart -- the config field is hidden, it is only ever written from here.
+	loadSavePresetOptions: function () {
+		let self = this;
+
+		let stored = self.config.savePresetOptions;
+
+		if (typeof stored !== 'object' || stored === null) {
+			return;
+		}
+
+		for (const option of c.SAVE_PRESET_OPTIONS) {
+			if (stored[option.key] !== undefined) {
+				self.data.savePresetOptions[option.key] = self.parseBoolean(stored[option.key]);
+			}
+		}
+	},
+
+	//Single write path for the toggles: set one (or every) option, persist,
+	//then push the change out to the variables and feedbacks.
+	setSavePresetOption: function (key, value) {
+		let self = this;
+
+		let keys = (key === 'all') ? c.SAVE_PRESET_OPTIONS.map((option) => option.key) : [key];
+
+		for (const name of keys) {
+			if (self.data.savePresetOptions[name] === undefined) {
+				self.log('info', `Unknown preset save option: ${name}`);
+				continue;
+			}
+
+			//'toggle' is resolved per option, so Toggle All flips each one
+			//individually rather than forcing them all to one state
+			self.data.savePresetOptions[name] = (value === 'toggle') ? !self.data.savePresetOptions[name] : self.parseBoolean(value);
+		}
+
+		self.config.savePresetOptions = { ...self.data.savePresetOptions };
+		self.saveConfig(self.config);
+
+		self.checkVariables();
+		self.checkFeedbacks();
 	},
 
 	clampPreset: function (value, fallback) {

--- a/src/variables.js
+++ b/src/variables.js
@@ -192,6 +192,15 @@ module.exports = {
 			variables.push({ variableId: 'presetSpeedValue', name: 'Preset Speed Value' })
 		}
 
+		//Save Preset options. These read back ON/OFF, which parseBoolean also
+		//accepts, so they drop straight into the variable mode of Preset - Save.
+		if (SERIES.actions.presets == true) {
+			for (const option of c.SAVE_PRESET_OPTIONS) {
+				variables.push({ variableId: 'savePresetOption_' + option.key, name: 'Save Preset Option - ' + option.label + ' ON/OFF' })
+			}
+			variables.push({ variableId: 'savePresetOptions', name: 'Save Preset Options - Summary' })
+		}
+
 		if (self.config.enableTracking) {
 			//build the auto tracking add on variables if enabled
 			variables.push({ variableId: 'tracking_autotracking', name: 'Auto Tracking - On/Off' })
@@ -580,6 +589,21 @@ module.exports = {
 			if (SERIES.variables.presetSpeedValue == true) {
 				let value = c.CHOICES_PSSPEED().find((PRESETSPEEDVALUE) => PRESETSPEEDVALUE.id == self.data.presetSpeedValue).varLabel;
 				variableValues.presetSpeedValue = value;
+			}
+
+			if (SERIES.actions.presets == true) {
+				let enabled = [];
+
+				for (const option of c.SAVE_PRESET_OPTIONS) {
+					let on = self.data.savePresetOptions[option.key] == true;
+					variableValues['savePresetOption_' + option.key] = on ? 'ON' : 'OFF';
+
+					if (on) {
+						enabled.push(option.short);
+					}
+				}
+
+				variableValues.savePresetOptions = enabled.length ? enabled.join(', ') : 'None';
 			}
 
 			if (self.config.enableTracking) {


### PR DESCRIPTION
#43/#67 added the ability to drive Save Preset's save options from custom variables (`use_variables_save`), so one set of switches could control what every camera saves. This PR builds on that by giving the module its own set of save-option variables and a matching toggle action — the same idea, but the variables live in the module instead of needing to be created by hand first.

Concretely:

- **New action** — *Preset - Set Save Option*: flips one option (or All) to On/Off/Toggle.
- **`savePset` gains a "Where the save options come from" dropdown**: *This button* (checkboxes, unchanged default) / *Module toggles* / *Variables*. This is additive to the existing variable-mode checkbox, not a replacement — `use_variables_save` still works and is migrated forward automatically via an upgrade script for anyone with existing buttons.
- **7 new variables**: `savePresetOption_ptz/focus/exposure/whitebalance/is/cp` (ON/OFF) and a `savePresetOptions` summary (e.g. `PTZ, Exp, WB`). These slot straight into the existing variable-mode inputs too, since they resolve to the same true/false format `parseBoolean` already accepts.
- **New feedback** — *Preset - Save Option State*.
- **New "Preset Save Options" preset category** — 6 toggle switches (green = saving), an All button, and a summary tile.
- Toggle state persists in config across restarts.
- HELP.md notes this was written with @claude.

Open to feedback on naming/placement if there's a preferred convention for module-owned vs. user-created variables in other modules — happy to adjust.

## Testing

`yarn test` passes on all 11 model profiles (net +8 presets, +1 action, +1 feedback, +7 variables vs. `main`). Also ran a 37-assertion script covering command-building in all three source modes, toggle/persist/restore, feedback states, and the upgrade script migrating old buttons.